### PR TITLE
Implement: Add ping endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# FastAPI Minimal Service
+
+## API Endpoints
+
+### GET /ping
+Returns a simple ping-pong response to verify the service is running.
+
+**Response**:
+```json
+{
+    "ping": "pong"
+}
+```
+
+**Status Code**: 200 OK

--- a/app/main.py
+++ b/app/main.py
@@ -9,3 +9,7 @@ async def root():
 @app.get("/health")
 async def health():
     return {"status": "ok"}
+
+@app.get("/ping")
+async def ping():
+    return {"ping": "pong"}


### PR DESCRIPTION
Implements story ping-endpoint-efe50518: Add ping endpoint

Acceptance Criteria:
Implement GET /ping returning HTTP 200 and {'ping':'pong'}; document the endpoint in README.md.