### PR TITLE
Implement: Add health check endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,3 +5,7 @@ app = FastAPI()
 @app.get("/")
 async def root():
     return {"message": "hello"}
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/app/test_main.py
+++ b/app/test_main.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from .main import app
+
+client = TestClient(app)
+
+def test_health():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi>=0.68.0
 uvicorn>=0.15.0
+pytest>=7.0.0
+httpx>=0.24.0


### PR DESCRIPTION
Implements story health-check-cfc1e302: Add health check endpoint

Acceptance Criteria:
Implement GET /health returning HTTP 200 and {'status':'ok'}; include a pytest that asserts status_code==200 and payload=={'status':'ok'}.