### PR TITLE
Implement: Add health and ping endpoints with tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,14 @@ from fastapi import FastAPI
 
 app = FastAPI()
 
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+@app.get("/ping")
+async def ping():
+    return {"ping": "pong"}
+
 @app.get("/")
 async def root():
     return {"message": "hello"}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_health_endpoint():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+def test_ping_endpoint():
+    response = client.get("/ping")
+    assert response.status_code == 200
+    assert response.json() == {"ping": "pong"}


### PR DESCRIPTION
Implements story 5c5f48d9-8a61-4e5d-b581-db56e5c77ea1: Add health and ping endpoints with tests

Acceptance Criteria:
Implement GET /health → 200 {'status':'ok'} and GET /ping → 200 {'ping':'pong'}; create tests/test_core.py using httpx/pytest that asserts both endpoints return the exact payloads and status codes.