### PR TITLE
Implement: Add health and ping endpoints with tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,3 +5,11 @@ app = FastAPI()
 @app.get("/")
 async def root():
     return {"message": "hello"}
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+@app.get("/ping")
+async def ping():
+    return {"ping": "pong"}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,17 @@
+import pytest
+from httpx import AsyncClient
+from app.main import app
+
+@pytest.mark.asyncio
+async def test_health_endpoint():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+@pytest.mark.asyncio
+async def test_ping_endpoint():
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.get("/ping")
+    assert response.status_code == 200
+    assert response.json() == {"ping": "pong"}


### PR DESCRIPTION
Implements story 7f759afc-399e-498f-966b-8d2f44287d0f: Add health and ping endpoints with tests

Acceptance Criteria:
Implement GET /health → 200 {'status':'ok'} and GET /ping → 200 {'ping':'pong'}; create tests/test_core.py using httpx/pytest that asserts both endpoints return the exact payloads and status codes.