### PR TITLE
Implement: Initialize repository structure

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,13 @@
+# Source Code
+
+This directory contains source code for the FastAPI application.
+
+## Structure
+
+- `utils/`: Utility functions and helpers
+- `services/`: Business logic services
+- `database/`: Database connection and session management
+
+## Usage
+
+This source code is imported and used by the main FastAPI application in the `app/` directory.


### PR DESCRIPTION
Implements story story-init-repo-structure-001: Initialize repository structure

Acceptance Criteria:
Repo contains src/, tests/, and docs/ directories with starter README